### PR TITLE
Snapshot btn #18

### DIFF
--- a/app/components/Binder.jsx
+++ b/app/components/Binder.jsx
@@ -3,6 +3,8 @@ import { browserHistory } from 'react-router'
 
 import firebase from 'APP/server/db'
 
+var Infinite = require('react-infinite')
+
 export default class extends React.Component {
   constructor(props) {
     super(props)
@@ -70,6 +72,7 @@ export default class extends React.Component {
           <span className='fa fa-plus-circle add-atom'
                 onClick={this.addAtom} />
         </div>
+        <Infinite containerHeight={400} elementHeight={26}>
         <div className='panel-body'>
           <ul id='binder-list'>
             {
@@ -95,6 +98,7 @@ export default class extends React.Component {
             }
           </ul>
         </div>
+        </Infinite>
       </div>
     )
   }

--- a/app/components/Chat.jsx
+++ b/app/components/Chat.jsx
@@ -28,7 +28,7 @@ export default class Chat extends React.Component {
   listenTo = (ref) => {
     if (this.unsubscribe) this.unsubscribe()
     // retreiving all messages for this project
-    const listener = ref.limitToLast(10).on('child_added', snapshot => {
+    const listener = ref.on('child_added', snapshot => {
       this.setState({ messages: [...this.state.messages, snapshot.val()] })
     })
     this.unsubscribe = () => {

--- a/app/components/CollabForm.jsx
+++ b/app/components/CollabForm.jsx
@@ -34,7 +34,7 @@ export default class extends React.Component {
       firebase.database().ref('users').child(snapshot.key).child('collaborations').child(this.props.projectId).remove()
       const deletedUserIndex = this.state.collabKeys.indexOf(snapshot.key)
       this.setState({collaborators: this.state.collaborators.splice(deletedUserIndex-1, 1), collabKeys: this.state.collabKeys.splice(deletedUserIndex-1, 1)})
-  })
+    })
     this.unsubscribe = () => ref.off('value', listener)
     this.unsubscribe = () => ref.off('value', removedCollabListener)
   }
@@ -64,6 +64,7 @@ export default class extends React.Component {
         this.setState({collaboratorEmail: ''})
         return firebase.database().ref().update(updates)
       }
+      this.setState({collaboratorEmail: ''})
     })
   }
   deleteCollab = (name, uid) => {
@@ -72,7 +73,7 @@ export default class extends React.Component {
   }
   render() {
     // console.log('state', this.state)
-    // console.log('props', this.props)  
+    // console.log('props', this.props)
     const collaborators = this.state.collaborators
     return (
       <div className="panel panel-default">
@@ -86,16 +87,16 @@ export default class extends React.Component {
                 <div>
                   <li className='collab-list' key={collab}>
                     {collab}
-                    <span className='fa fa-times delete-collab' 
+                    <span className='fa fa-times delete-collab'
                           onClick={() => this.deleteCollab(collab, this.state.collabKeys[idx])}>
                     </span>
                   </li>
                 </div>)
-              }) }
+            }) }
           </ul>
           <form onSubmit={this.handleSubmit}>
             <label>Collaborator Email</label>
-            <input value={this.state.collaboratorEmail} type='text' onChange={this.handleChange} />
+            <input value={this.state.collaboratorEmail} type='text' onChange={this.handleChange} value={this.state.collaboratorEmail}/>
             <button type='submit'>Add Collaborator</button>
           </form>
         </div>

--- a/app/components/Editor.jsx
+++ b/app/components/Editor.jsx
@@ -44,7 +44,11 @@ export default class extends React.Component {
     const text = this.props.atom ? this.props.atom.text : ''
     return (
       <div>
-        <button type="submit" onClick={this.props.snapshot}>Snapshot</button>
+        <form onSubmit={this.props.snapshot}>
+          <label>Save current version as: </label>
+          <input type='text' onChange={this.props.handleChange} value={this.props.snapshotName}/>
+          <button type="submit" >Save</button>
+        </form>
         <div className="editor-panel">
           <ReactQuill id='react-quill'
             value={this.state.value}

--- a/app/components/Editor.jsx
+++ b/app/components/Editor.jsx
@@ -44,10 +44,13 @@ export default class extends React.Component {
     const text = this.props.atom ? this.props.atom.text : ''
     return (
       <div>
-        <ReactQuill id='react-quill'
-          value={this.state.value}
-          onChange={this.write}
-          theme={'snow'} />
+        <button type="submit" onClick={this.props.snapshot}>Snapshot</button>
+        <div className="editor-panel">
+          <ReactQuill id='react-quill'
+            value={this.state.value}
+            onChange={this.write}
+            theme={'snow'} />
+        </div>
       </div>
     )
   }

--- a/app/containers/AtomEditor.jsx
+++ b/app/containers/AtomEditor.jsx
@@ -12,6 +12,7 @@ export default class AtomEditor extends React.Component {
     super(props)
     this.state = {
       atomVal: {},
+      snapshotName: '',
     }
   }
 
@@ -36,22 +37,29 @@ export default class AtomEditor extends React.Component {
       atomRef.off('value', listener)
     }
   }
+  handleChange = (evt) => {
+    this.setState({snapshotName: evt.target.value})
+  }
+
   snapshot = (evt) => {
     evt.preventDefault()
     projectsRef.child(this.props.projectId).once('value', snapshot => {
       const snapshotObj = snapshot.val()
+      snapshotObj.title = this.state.snapshotName
       snapshotObj.timeStamp = Date.now() // can format as needed
       snapshotObj.snapshots = null // removing snapshots of new snapshot to preserve space
       snapshotObj.messages = null // removing messages of new snapshot to preserve space
+      snapshotObj.collaborators = null // removing collaborators from snapshot
       projectsRef.child(this.props.projectId + '/snapshots').push(snapshotObj)
     })
+    this.setState({snapshotName: ''})
   }
   render() {
     const ref = this.state.atomRef || projectsRef.child(this.props.projectId).child('current').child('atoms').child(this.props.atomId)
     return (
       <div>
         <div className='col-xs-6 project-center'>
-          <Editor atomRef={ref} snapshot={this.snapshot}/>
+          <Editor atomRef={ref} snapshot={this.snapshot} handleChange={this.handleChange} snapshotName={this.state.snapshotName}/>
         </div>
         <div className='col-xs-3 sidebar-right'>
           <Summary atomRef={ref} />

--- a/app/containers/AtomEditor.jsx
+++ b/app/containers/AtomEditor.jsx
@@ -42,6 +42,7 @@ export default class AtomEditor extends React.Component {
       const snapshotObj = snapshot.val()
       snapshotObj.timeStamp = Date.now() // can format as needed
       snapshotObj.snapshots = null // removing snapshots of new snapshot to preserve space
+      snapshotObj.messages = null // removing messages of new snapshot to preserve space
       projectsRef.child(this.props.projectId + '/snapshots').push(snapshotObj)
     })
   }

--- a/app/containers/AtomEditor.jsx
+++ b/app/containers/AtomEditor.jsx
@@ -37,9 +37,6 @@ export default class AtomEditor extends React.Component {
     }
   }
 
-  updateAtom = (updateObj) =>
-    projectsRef.child(this.props.params.id).child('current').child('atoms').child(this.props.params.atomId).update(updateObj)
-
   render() {
     const ref = this.state.atomRef || projectsRef.child(this.props.projectId).child('current').child('atoms').child(this.props.atomId)
     return (

--- a/app/containers/AtomEditor.jsx
+++ b/app/containers/AtomEditor.jsx
@@ -36,13 +36,21 @@ export default class AtomEditor extends React.Component {
       atomRef.off('value', listener)
     }
   }
-
+  snapshot = (evt) => {
+    evt.preventDefault()
+    projectsRef.child(this.props.projectId).once('value', snapshot => {
+      const snapshotObj = snapshot.val()
+      snapshotObj.timeStamp = Date.now() // can format as needed
+      snapshotObj.snapshots = null // removing snapshots of new snapshot to preserve space
+      projectsRef.child(this.props.projectId + '/snapshots').push(snapshotObj)
+    })
+  }
   render() {
     const ref = this.state.atomRef || projectsRef.child(this.props.projectId).child('current').child('atoms').child(this.props.atomId)
     return (
       <div>
         <div className='col-xs-6 project-center'>
-          <Editor atomRef={ref} />
+          <Editor atomRef={ref} snapshot={this.snapshot}/>
         </div>
         <div className='col-xs-3 sidebar-right'>
           <Summary atomRef={ref} />

--- a/public/style.css
+++ b/public/style.css
@@ -87,7 +87,6 @@ body {
     float: right;
 }
 
-
 /*
 #atom-name {
     background-color: red;


### PR DESCRIPTION
closes #18 

this.snapshot() function is in AtomEditor, but triggered in Editor.
Had to move snapshot to top of editor b/c of that weird spacing issue at the bottom of quill that I tried to figure out but couldn't...

Also, we're not saving snapshots/messages of project in the new snapshot - list of old snapshots/messages are already in current project and are not being overwritten. If anyone disagrees, it's easy to remove.